### PR TITLE
Document GitHub Pages deployment and add .nojekyll marker

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 _Create a site or blog from your GitHub repositories with GitHub Pages._
 
+## Deploy to GitHub Pages
+
+1. Push this repository to GitHub.
+2. In your repository, open **Settings → Pages**.
+3. Under **Build and deployment**, select **Deploy from a branch**.
+4. Choose the branch you want to publish (for example, `main`) and the root folder.
+5. Save. GitHub Pages will publish `index.html` and `styles.css` from the repository root.
+
+> Tip: This project includes a `.nojekyll` file to ensure GitHub Pages serves the site as static assets.
+
 </header>
 
 <!--

--- a/index.html
+++ b/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Alex Rivera | Nursing Student Portfolio</title>
+    <meta
+      name="description"
+      content="Minimalist portfolio for a nursing student featuring education, clinical experience, projects, and contact details."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="logo" href="#top">AR</a>
+        <div class="nav-links">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#projects">Projects</a>
+          <a href="#contact">Contact</a>
+        </div>
+        <a class="button ghost" href="mailto:hello@nursingportfolio.com">Email me</a>
+      </nav>
+    </header>
+
+    <main id="top">
+      <section class="hero">
+        <div class="hero-content">
+          <p class="eyebrow">Nursing student · Patient-centered care</p>
+          <h1>Alex Rivera</h1>
+          <p class="lead">
+            Nursing student focused on holistic care, clinical excellence, and patient advocacy. I enjoy
+            translating complex medical information into compassionate, easy-to-understand support.
+          </p>
+          <div class="hero-actions">
+            <a class="button" href="#contact">Start a conversation</a>
+            <a class="button ghost" href="resume.pdf">Download resume</a>
+          </div>
+        </div>
+        <div class="hero-card">
+          <img
+            src="https://images.unsplash.com/photo-1505751172876-fa1923c5c528?auto=format&fit=crop&w=800&q=80"
+            alt="Nursing student in a clinical setting"
+          />
+          <div class="hero-card-body">
+            <p class="label">Currently</p>
+            <p>B.S.N. Candidate, Class of 2026</p>
+            <p class="label">Location</p>
+            <p>Seattle, WA (open to relocation)</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="section">
+        <div class="section-header">
+          <h2>About</h2>
+          <p>Evidence-based care, empathy, and teamwork guide my approach.</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <p>
+              I am a junior nursing student with a passion for medical-surgical nursing and community
+              health. My clinical rotations have strengthened my skills in patient assessments,
+              medication administration, and interdisciplinary communication.
+            </p>
+            <p>
+              I value calm, organized workflows and create supportive environments for patients and
+              their families. I am seeking opportunities to contribute to a collaborative care team
+              while expanding my clinical competencies.
+            </p>
+          </div>
+          <ul class="highlights">
+            <li>
+              <span>Clinical skills</span>
+              <p>Vitals, head-to-toe assessment, wound care, IV therapy.</p>
+            </li>
+            <li>
+              <span>Certifications</span>
+              <p>BLS, HIPAA, Infection Control, Patient Safety.</p>
+            </li>
+            <li>
+              <span>Languages</span>
+              <p>English, Spanish (conversational).</p>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="experience" class="section">
+        <div class="section-header">
+          <h2>Clinical experience</h2>
+          <p>Recent rotations and hands-on practice.</p>
+        </div>
+        <div class="timeline">
+          <article>
+            <div>
+              <h3>Medical-Surgical Rotation</h3>
+              <p class="meta">Harborview Medical Center · 2024</p>
+            </div>
+            <ul>
+              <li>Conducted comprehensive patient assessments and documented care plans.</li>
+              <li>Collaborated with RNs and CNAs on daily care routines and discharge planning.</li>
+              <li>Provided patient education on post-op recovery and medication adherence.</li>
+            </ul>
+          </article>
+          <article>
+            <div>
+              <h3>Community Health Clinic</h3>
+              <p class="meta">Rainier Family Health · 2023</p>
+            </div>
+            <ul>
+              <li>Assisted with wellness screenings and vaccine clinics.</li>
+              <li>Observed interdisciplinary case conferences for chronic care management.</li>
+              <li>Promoted health literacy through clear, culturally sensitive education.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="section-header">
+          <h2>Projects & leadership</h2>
+          <p>Highlights that showcase initiative and teamwork.</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>Senior capstone proposal</h3>
+            <p>
+              Designing a patient education toolkit to improve medication adherence for post-discharge
+              cardiac patients.
+            </p>
+            <a href="#">View outline</a>
+          </article>
+          <article class="card">
+            <h3>Nursing peer mentor</h3>
+            <p>
+              Supported first-year nursing students with study planning, lab preparation, and
+              clinical readiness.
+            </p>
+            <a href="#">Program details</a>
+          </article>
+          <article class="card">
+            <h3>Health equity volunteer</h3>
+            <p>
+              Partnered with local organizations to deliver blood pressure screenings and health
+              education.
+            </p>
+            <a href="#">Volunteer recap</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <h2>Education</h2>
+          <p>Academic background and coursework.</p>
+        </div>
+        <div class="grid two">
+          <div class="card">
+            <h3>Bachelor of Science in Nursing</h3>
+            <p class="meta">University of Washington · 2022 - 2026</p>
+            <ul>
+              <li>GPA: 3.8</li>
+              <li>Honors: Dean's List (4 semesters)</li>
+              <li>Relevant coursework: Pathophysiology, Pharmacology, Maternal-Child Nursing</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Leadership</h3>
+            <ul>
+              <li>Student Nurses Association, Events Coordinator</li>
+              <li>Simulation Lab Assistant</li>
+              <li>Volunteer, Seattle Community Health Fair</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="contact">
+        <div class="section-header">
+          <h2>Contact</h2>
+          <p>Let's connect about clinical opportunities and collaborations.</p>
+        </div>
+        <div class="contact-card">
+          <div>
+            <h3>Get in touch</h3>
+            <p>Email: <a href="mailto:hello@nursingportfolio.com">hello@nursingportfolio.com</a></p>
+            <p>Phone: (555) 123-4567</p>
+            <p>LinkedIn: <a href="https://www.linkedin.com">linkedin.com/in/alexrivera</a></p>
+          </div>
+          <form class="form">
+            <label>
+              Name
+              <input type="text" placeholder="Your name" />
+            </label>
+            <label>
+              Email
+              <input type="email" placeholder="you@email.com" />
+            </label>
+            <label>
+              Message
+              <textarea rows="4" placeholder="How can I help?"></textarea>
+            </label>
+            <button type="button" class="button">Send message</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© 2024 Alex Rivera · Nursing student portfolio</p>
+      <p class="small">Customize the colors, text, and links in this template to make it yours.</p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,306 @@
+:root {
+  --bg: #f9f9f7;
+  --surface: #ffffff;
+  --text: #1f1f1f;
+  --muted: #5d5d5d;
+  --accent: #2f6f6d;
+  --accent-soft: rgba(47, 111, 109, 0.12);
+  --border: #e6e5e1;
+  --shadow: 0 24px 40px rgba(0, 0, 0, 0.08);
+  --radius: 18px;
+  --max-width: 1100px;
+  --font: "Inter", "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  width: 100%;
+  display: block;
+  border-radius: var(--radius);
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 4.5rem;
+  padding: 0 1.5rem 6rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(249, 249, 247, 0.95);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.logo {
+  font-weight: 700;
+  border: 1px solid var(--border);
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin: 0.6rem 0 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.button {
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 30px rgba(47, 111, 109, 0.25);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.hero-card {
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.hero-card-body {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+  color: var(--muted);
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.section-header h2 {
+  font-size: 2rem;
+}
+
+.section-header p {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlights {
+  list-style: none;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.highlights li {
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.highlights span {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline article {
+  padding: 1.5rem;
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 1rem;
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.timeline ul,
+.card ul {
+  padding-left: 1.2rem;
+  color: var(--muted);
+}
+
+.card {
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 1rem;
+}
+
+.card a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.contact-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 2rem;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+input,
+textarea {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  font: inherit;
+  background: #fff;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.site-footer .small {
+  font-size: 0.85rem;
+  margin-top: 0.4rem;
+}
+
+@media (max-width: 720px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero {
+    padding-top: 2rem;
+  }
+
+  .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide clear, step-by-step instructions so the portfolio can be published to GitHub Pages from the repository root.
- Ensure GitHub serves the static `index.html`/`styles.css` files as-is by disabling Jekyll processing with a `.nojekyll` marker.

### Description
- Add a **Deploy to GitHub Pages** section to `README.md` with numbered steps to publish the site and a tip referencing `index.html` and `styles.css` in the repo root.
- Add a `.nojekyll` file containing `# Disable Jekyll processing` to prevent Jekyll from processing the site and ensure static asset delivery.

### Testing
- No automated tests were run because this is a documentation-only change; the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c6165ed0832eabb411228e6d5982)